### PR TITLE
ZENG-253105 Derive RemoteSystemProperties from MasterToSlaveCallable

### DIFF
--- a/src/main/java/com/compuware/jenkins/zadviser/build/RemoteSystemProperties.java
+++ b/src/main/java/com/compuware/jenkins/zadviser/build/RemoteSystemProperties.java
@@ -1,7 +1,7 @@
 /**
  * The MIT License (MIT)
  * 
- * Copyright (c) 2020 Compuware Corporation
+ * Copyright (c) 2022 Compuware Corporation
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
@@ -16,28 +16,18 @@
  */
 package com.compuware.jenkins.zadviser.build;
 
-import hudson.remoting.Callable;
 import java.util.Properties;
-import org.jenkinsci.remoting.RoleChecker;
+
+import jenkins.security.MasterToSlaveCallable;
 
 /**
  * Get remote system properties
  */
-public class RemoteSystemProperties implements Callable<Properties, RuntimeException> {
+public class RemoteSystemProperties extends MasterToSlaveCallable<Properties, RuntimeException> {
 
 	private static final long serialVersionUID = 4501207510446994815L;
 
 	public Properties call() {
 		return System.getProperties();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.jenkinsci.remoting.RoleSensitive#checkRoles(org.jenkinsci.remoting.RoleChecker)
-	 */
-	@Override
-	public void checkRoles(RoleChecker checker) {
-		// Implementation required by interface, but not using
 	}
 }


### PR DESCRIPTION
Fixes Jenkins security issue 2630 by deriving RemoteSystemProperties from MasterToSlaveCallabled

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
